### PR TITLE
Content import with internal wordpress links

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+from django.contrib.admin import ModelAdmin
+
+from . import models
+
+
+@admin.register(models.WordpressMapping)
+class WordpressMappingAdmin(ModelAdmin):
+    list_display = ("wp_url", "wp_post_id", "page", "image", "document")

--- a/blog/management/commands/wordpress_to_wagtail.py
+++ b/blog/management/commands/wordpress_to_wagtail.py
@@ -509,13 +509,13 @@ class Command(BaseCommand):
                     post_model_kwargs["translation_key"] = uuid.uuid4()
                 else:
                     translation.activate("de")
-            if any(c["slug"] == "fr" for c in categories):
+            elif any(c["slug"] == "fr" for c in categories):
                 if self.wagtail_locale:
                     locale = Locale.objects.get(language_code="fr")
                     post_model_kwargs["translation_key"] = uuid.uuid4()
                 else:
                     translation.activate("fr")
-            if any(c["slug"] == "ar" for c in categories):
+            elif any(c["slug"] == "ar" for c in categories):
                 if self.wagtail_locale:
                     locale = Locale.objects.get(language_code="ar")
                     post_model_kwargs["translation_key"] = uuid.uuid4()


### PR DESCRIPTION
* [x] Fix locale bug in import
* [x] Internal links to `?p=<...>`
* [x] `wp-content` links
* [x] Use Wagtail's internals for references to pages, images and documents (to avoid hard-linking slugs and having 404s when contents move)

Fixes #90 