### PR TITLE
Tidy up all Wordpress HTML

### DIFF
--- a/blog/management/commands/wordpress_to_wagtail.py
+++ b/blog/management/commands/wordpress_to_wagtail.py
@@ -6,6 +6,7 @@ import uuid
 from uuid import uuid4
 
 import bleach
+import tidy
 from bleach.sanitizer import ALLOWED_TAGS
 from bs4 import BeautifulSoup
 from django.apps import apps
@@ -633,9 +634,11 @@ class Command(BaseCommand):
             element.decompose()
 
         # Clean up unclosed tags
-        body = soup.decode_contents()
+        new_body = tidy.parseString(body, wrap=0, force_output=True)
+        if not new_body:
+            print("Could not parse HTML at all, must be some real garbage :)")
         return bleach.clean(
-            body,
+            new_body,
             tags=ALLOWED_TAGS + ["p", "h1", "h2", "h3", "h4", "h5", "caption", "img"],
             attributes=["href", "src", "alt"],
             strip=True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ wagtail-localize>=1.0.1,<1.2
 wagtail-footnotes>=0.8.1,<0.10
 lxml>=4.7
 sorl-thumbnail
+uTidylib==0.8


### PR DESCRIPTION
This needs to be done during the import since Wagtail actually also stores invalid HTML (because of its Richtext parsing).