### PR TITLE
Import unique slug and locale

### DIFF
--- a/blog/management/commands/wordpress_to_wagtail.py
+++ b/blog/management/commands/wordpress_to_wagtail.py
@@ -786,48 +786,34 @@ class Command(BaseCommand):
         origin_url,
         **kwargs,
     ):
+        mappings = self.mappings(
+            index,
+            locale,
+            post_id,
+            published,
+            title,
+            date,
+            slug,
+            body,
+            excerpt,
+            user,
+            authors,
+            meta,
+            origin_url,
+        )
+
+        if mappings.get("locale") and mappings.get("locale") != locale:
+            locale = mappings.get("locale")
+            index = index._meta.model.objects.get(
+                slug=index.slug, locale=mappings.get("locale")
+            )
+            print("Changed to index: {} {}".format(index, index.locale))
 
         try:
-            new_entry = self.PostModel.objects.get(slug=slug)
-            for k, v in self.mappings(
-                index,
-                locale,
-                post_id,
-                published,
-                title,
-                date,
-                slug,
-                body,
-                excerpt,
-                user,
-                authors,
-                meta,
-                origin_url,
-            ).items():
+            new_entry = self.PostModel.objects.get(slug=slug, locale=locale)
+            for k, v in mappings.items():
                 setattr(new_entry, k, v)
         except self.PostModel.DoesNotExist:
-
-            mappings = self.mappings(
-                index,
-                locale,
-                post_id,
-                published,
-                title,
-                date,
-                slug,
-                body,
-                excerpt,
-                user,
-                authors,
-                meta,
-                origin_url,
-            )
-
-            if mappings.get("locale") != locale:
-                index = index._meta.model.objects.get(
-                    slug=index.slug, locale=mappings.get("locale")
-                )
-                print("Changed to index: {} {}".format(index, index.locale))
 
             try:
                 new_entry = index.add_child(

--- a/blog/management/commands/wordpress_to_wagtail.py
+++ b/blog/management/commands/wordpress_to_wagtail.py
@@ -23,6 +23,7 @@ from django.utils.html import linebreaks
 from django.utils.text import slugify
 from PIL import Image as PILImage
 from wagtail.core.models import Locale
+from wagtail.core.models import Page
 from wagtail.images import get_image_model
 from wagtail_footnotes.models import Footnote
 
@@ -810,10 +811,15 @@ class Command(BaseCommand):
             print("Changed to index: {} {}".format(index, index.locale))
 
         try:
-            new_entry = self.PostModel.objects.get(slug=slug, locale=locale)
+            new_entry = (
+                index.get_children()
+                .exact_type(self.PostModel)
+                .specific()
+                .get(slug=slug)
+            )
             for k, v in mappings.items():
                 setattr(new_entry, k, v)
-        except self.PostModel.DoesNotExist:
+        except Page.DoesNotExist:
 
             try:
                 new_entry = index.add_child(


### PR DESCRIPTION
Fixes #128 

By simply resolving a slug and locale, we were getting pages nested in the wrong language version of a Wiki index. Instead, we look up *only* pages of the index that we think it should be nested in.