### PR TITLE
Divide the wiki index page into categories

### DIFF
--- a/home/templatetags/migcontrol_tags.py
+++ b/home/templatetags/migcontrol_tags.py
@@ -167,3 +167,11 @@ def get_sub_menus(page, fixed_level=None, maxdepth=2, specific=True):
 @register.filter("startswith")
 def startswith(text, starts):
     return text.startswith(starts)
+
+
+@register.filter()
+def migcontrol_relative_url_path(url_path, locale_id):
+
+    url_parts = url_path.split("/")
+    url_parts = [""] + [locale_id] + url_parts[2:]
+    return "/".join(url_parts)

--- a/wiki/models.py
+++ b/wiki/models.py
@@ -59,7 +59,17 @@ class WikiIndexPage(Page):
     def get_context(self, request):
         context = super().get_context(request)
         context["wiki_pages"] = (
-            self.get_children().live().type(WikiPage).order_by("title")
+            self.get_children()
+            .live()
+            .type(WikiPage)
+            .specific()
+            .values(
+                "title",
+                "url_path",
+                "locale__language_code",
+                "wikipage__wiki_categories__wiki_category__name",
+            )
+            .order_by("wikipage__wiki_categories__wiki_category__name", "title")
         )
         return context
 

--- a/wiki/templates/wiki/index.html
+++ b/wiki/templates/wiki/index.html
@@ -1,16 +1,45 @@
 {% extends "base.html" %}
 {% load static %}
+{% load wagtailcore_tags %}
+{% load migcontrol_tags %}
+{% load i18n %}
 
 {% block content %}
 
 <h1 class="migcontrol-page-title">{{ page.title }}</h1>
 
-On this page, we'll list all the entries of the wiki by their categories (TODO).
-
-<ul>
-{% for wiki_page in wiki_pages %}
-  <li><a href="{{ wiki_page.url }}">{{ wiki_page.title }}</a></li>
+{% for block in page.body %}
+  {% include_block block %}
 {% endfor %}
-</ul>
+
+{% for category in wiki_categories %}
+{{ category }}
+{% endfor %}
+
+<h2 class="mb-3">{% trans "Categories" %}</h2>
+
+<div class="row row-cols-1 row-cols-md-3 g-4">
+
+  {% for wiki_page in wiki_pages %}
+    {% ifchanged wiki_page.wikipage__wiki_categories__wiki_category__name %}
+      {% if not forloop.first %}
+      </ul>
+      </div>
+      </div>
+      {% endif %}
+      <div class="col">
+      <div class="card">
+        <div class="card-header">
+          {{ wiki_page.wikipage__wiki_categories__wiki_category__name|default:_("Uncategorized") }}
+        </div>
+      <ul class="list-group list-group-flush">
+    {% endifchanged %}
+    <li class="list-group-item"><a href="{{ wiki_page.url_path|migcontrol_relative_url_path:wiki_page.locale__language_code }}">{{ wiki_page.title }}</a></li>
+  {% endfor %}
+  </ul>
+  </div>
+  </div>
+
+</div>
 
 {% endblock content %}


### PR DESCRIPTION
Fixes #117 

Looks kind of like this - but you need to add the introduction body via the Wagtail page editing of the Wiki index page itself (and for each language).

![image](https://user-images.githubusercontent.com/374612/196813577-df3148fe-331d-43d5-9293-e142b38ec9e4.png)
