### PR TITLE
Use manually controlled publication datetime fields with automatic fallbacks

### DIFF
--- a/library/templates/library/media_page.html
+++ b/library/templates/library/media_page.html
@@ -18,7 +18,7 @@
 
 <p class="text-primary">
   <span class="fa fa-clock"></span>
-  {% trans "Last updated" %} {{ page.last_published_at|default:page.first_published_at|date:"F jS, Y" }}
+  {% trans "Published" %} {{ page.go_live_at|default:page.first_published_at|date:"F jS, Y" }}
 </p>
 
 {{ page.body|richtext }}

--- a/wiki/templates/wiki/wiki_page.html
+++ b/wiki/templates/wiki/wiki_page.html
@@ -19,7 +19,7 @@
 
 <p class="text-primary">
   <span class="fa fa-clock"></span>
-  {% trans "Last updated" %} {{ page.last_published_at|default:page.first_published_at|date:"F jS, Y" }}
+  {% trans "Published" %} {{ page.go_live_at|default:page.first_published_at|date:"F jS, Y" }}
     {% if page.authors %}
     - {% trans "written by" %}: {{ page.authors|default:"" }}
     {% endif %}


### PR DESCRIPTION
Fixes https://github.com/migcontrol/django-migcontrol/issues/187