### PR TITLE
Render page body on library index sidebar

### DIFF
--- a/library/templates/library/index.html
+++ b/library/templates/library/index.html
@@ -6,23 +6,25 @@
 
 {% block sidebar %}
 
-<h4>{% trans "Search filter" %}</h4>
+  <h4>{% trans "Search filter" %}</h4>
 
-<form method="GET">
+  <form method="GET">
 
-  {% bootstrap_form filter_form %}
+    {% bootstrap_form filter_form %}
 
-  {% bootstrap_buttons submit=_("Filter") %}
+    {% bootstrap_buttons submit=_("Filter") %}
 
-</form>
+  </form>
+
+  {% for block in page.body %}
+    {% include_block block %}
+  {% endfor %}
 
 {% endblock %}
 
 {% block content %}
 
 <h1 class="migcontrol-page-title">{{ page.title }} ({{ media_pages.count }} {% trans "results" %})</h1>
-
-{% include_block page.body %}
 
 <table class="table table-sm table-bordered table-striped">
 


### PR DESCRIPTION
Fixes https://github.com/migcontrol/django-migcontrol/issues/199

![image](https://github.com/migcontrol/django-migcontrol/assets/374612/8552fa9f-f340-4253-b26d-84116e02f2a6)
