### PR TITLE
Allow unicode characters in anchor slugs

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -11,8 +11,8 @@ from django.core.paginator import Paginator
 from django.db import models
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
-from django.template.defaultfilters import slugify
 from django.utils.html import format_html
+from django.utils.text import slugify
 from modelcluster.fields import ParentalKey
 from modelcluster.tags import ClusterTaggableManager
 from taggit.models import Tag
@@ -343,7 +343,7 @@ class BlogPage(Page):
                 getattr(soup, attr).unwrap()
 
         for element in soup.find_all(["h1", "h2", "h3", "h4", "h5"]):
-            element["id"] = "header-" + slugify(element.text)
+            element["id"] = "header-" + slugify(element.text, allow_unicode=True)
 
         return str(soup)
 

--- a/home/models.py
+++ b/home/models.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
 from django.db import models  # noqa
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
@@ -116,7 +116,7 @@ class ArticleBase(models.Model):
                 getattr(soup, attr).unwrap()
 
         for element in soup.find_all(["h1", "h2", "h3", "h4", "h5"]):
-            element["id"] = "header-" + slugify(element.text)
+            element["id"] = "header-" + slugify(element.text, allow_unicode=True)
 
         return str(soup)
 

--- a/home/templatetags/migcontrol_tags.py
+++ b/home/templatetags/migcontrol_tags.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.core.files.storage import FileSystemStorage
 from django.utils import translation
 from django.utils.safestring import mark_safe
+from django.utils.text import slugify
 from sorl.thumbnail import get_thumbnail
 from wagtail.core.models import Site
 from wagtail.core.templatetags.wagtailcore_tags import pageurl
@@ -175,3 +176,8 @@ def migcontrol_relative_url_path(url_path, locale_id):
     url_parts = url_path.split("/")
     url_parts = [""] + [locale_id] + url_parts[2:]
     return "/".join(url_parts)
+
+
+@register.filter()
+def slugify_unicode(words):
+    return slugify(words, allow_unicode=True)

--- a/migcontrol/templates/migcontrol/includes/toc_section.html
+++ b/migcontrol/templates/migcontrol/includes/toc_section.html
@@ -1,4 +1,5 @@
-  <a class="nav-link" href="#header-{{ section|slugify }}">{{ section }}</a>
+{% load migcontrol_tags %}
+  <a class="nav-link" href="#header-{{ section|slugify_unicode }}">{{ section }}</a>
   {% if children %}
   <nav class="nav nav-pills flex-column ms-3 my-1">
     {% for sub_section, sub_children in children %}

--- a/wiki/models.py
+++ b/wiki/models.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
 from django.db import models
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from django_countries.fields import CountryField
 from modelcluster.fields import ParentalKey
@@ -180,6 +180,6 @@ class WikiPage(Page):
 
         # Now let's add some id=... attributes to all h{1,2,3,4,5}
         for element in soup.find_all(["h1", "h2", "h3", "h4", "h5"]):
-            element["id"] = "header-" + slugify(element.text)
+            element["id"] = "header-" + slugify(element.text, allow_unicode=True)
 
         return str(soup)


### PR DESCRIPTION
Fixes https://github.com/migcontrol/django-migcontrol/issues/202