### PR TITLE
Add missing footnote panel to blog post editor

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -433,6 +433,7 @@ BlogPage.content_panels = [
     FieldPanel("header_image"),
     FieldPanel("body_richtext", classname="collapsed"),
     FieldPanel("body_mixed"),
+    InlinePanel("footnotes", label="Footnotes"),
 ]
 
 


### PR DESCRIPTION
Fixes https://github.com/migcontrol/django-migcontrol/issues/188