### PR TITLE
Remove scrolling from wiki category cards

### DIFF
--- a/migcontrol/static/scss/wiki.scss
+++ b/migcontrol/static/scss/wiki.scss
@@ -1,4 +1,4 @@
 .wiki-list-group {
-    max-height: 200px;
-    overflow-y: auto;
+    /* max-height: 200px; */
+    /* overflow-y: auto; */
 }


### PR DESCRIPTION
I'm not sure if this really fixes https://github.com/migcontrol/django-migcontrol/issues/249 since we had it without scrolling before.

The best solution is probably that some sites down and thinks about what layout is desirable for this particular landing page :)